### PR TITLE
fix revenant UNKNOWNCORECHIP max amount

### DIFF
--- a/application/src/main/java/nl/jixxed/eliteodysseymaterials/enums/Manufactured.java
+++ b/application/src/main/java/nl/jixxed/eliteodysseymaterials/enums/Manufactured.java
@@ -117,6 +117,14 @@ public enum Manufactured implements HorizonsMaterial {
     }
 
     @Override
+	public int getMaxAmount() {
+        if (this == UNKNOWNCORECHIP) {
+            return 100;
+        }
+        return this.getRarity().getMaxAmount();
+	}
+
+    @Override
     public HorizonsStorageType getStorageType() {
         return HorizonsStorageType.MANUFACTURED;
     }


### PR DESCRIPTION
tactical core chip max amount is 100.

[https://github.com/im97mori-github/ed-odyssey-materials-helper/blob/853715764a2e873bcedd7862dcd4bf5f52a65222/tacticalcorechip.png](url)